### PR TITLE
version 0.1.16がpublishされるまで固定

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@popperjs/core": "^2.11.5",
     "@prisma/client": "^3.14.0",
     "bootstrap": "^5.1.3",
-    "bootstrap-vue-3": "^0.1.13",
+    "bootstrap-vue-3": "0.1.13",
     "lodash": "^4.17.21",
     "vue": "^3.2.37"
   },


### PR DESCRIPTION
https://github.com/imamiya-masaki/image-busy/issues/4

こやつの修正
0.1.14(と多分0.1.15も)がバグっているので、
使用不可

0.1.16の修正が入ったnpmパッケージがpublishされたら、
^0.1.16に変更する